### PR TITLE
fix: resolve event time display timezone issue (#102)

### DIFF
--- a/app/components/events/EventsListing.tsx
+++ b/app/components/events/EventsListing.tsx
@@ -7,6 +7,7 @@ import { Container } from "../shared/Container";
 import EventsPagination from "./EventsPagination";
 import { motion } from "motion/react";
 import { PageTitle } from "../shared/PageTitle";
+import { formatEventTime, formatEventDate, formatEventTimeRange } from "@/sanity/lib/dateFormatters";
 
 const container = {
   hidden: { opacity: 0 },
@@ -174,22 +175,9 @@ export const EventsListing = ({
                         <path d="m612-292 56-56-148-148v-184h-80v216l172 172ZM480-80q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-400Zm0 320q133 0 226.5-93.5T800-480q0-133-93.5-226.5T480-800q-133 0-226.5 93.5T160-480q0 133 93.5 226.5T480-160Z" />
                       </svg>
                       <span>
-                        {new Date(featuredEvent.startDate).toLocaleTimeString(
-                          "en-US",
-                          {
-                            hour: "numeric",
-                            minute: "2-digit",
-                            hour12: true,
-                          }
-                        )}{" "}
-                        -{" "}
-                        {new Date(featuredEvent.endDate).toLocaleTimeString(
-                          "en-US",
-                          {
-                            hour: "numeric",
-                            minute: "2-digit",
-                            hour12: true,
-                          }
+                        {formatEventTimeRange(
+                          featuredEvent.startDate,
+                          featuredEvent.endDate
                         )}
                       </span>
                     </div>
@@ -300,22 +288,10 @@ export const EventsListing = ({
                 // Calculate time display
                 let timeDisplay = "TBA";
                 if (event.endDate) {
-                  const startTime = new Date(
-                    event.startDate
-                  ).toLocaleTimeString("en-US", {
-                    hour: "numeric",
-                    minute: "2-digit",
-                    hour12: true,
-                  });
-                  const endTime = new Date(event.endDate).toLocaleTimeString(
-                    "en-US",
-                    {
-                      hour: "numeric",
-                      minute: "2-digit",
-                      hour12: true,
-                    }
+                  timeDisplay = formatEventTimeRange(
+                    event.startDate,
+                    event.endDate
                   );
-                  timeDisplay = `${startTime} - ${endTime}`;
                 }
 
                 return (

--- a/app/events/[slug]/page.tsx
+++ b/app/events/[slug]/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import SimilarEventsCarousel from "@/app/components/events/SimilarEventsCarousel";
 import PhotoGalleryWithLightbox from "@/app/components/events/PhotoGalleryWithLightbox";
+import { formatEventTime, formatEventDate, formatEventTimeRange } from "@/sanity/lib/dateFormatters";
 
 // Force dynamic rendering for development
 export const dynamic = "force-dynamic";
@@ -35,19 +36,11 @@ export default async function EventDetailPage({
 
   // Format date display
   const formatDate = (date: string) => {
-    return new Date(date).toLocaleDateString("en-US", {
-      month: "long",
-      day: "numeric",
-      year: "numeric",
-    });
+    return formatEventDate(date);
   };
 
   const formatTime = (date: string) => {
-    return new Date(date).toLocaleTimeString("en-US", {
-      hour: "numeric",
-      minute: "2-digit",
-      hour12: true,
-    });
+    return formatEventTime(date);
   };
 
   const dateDisplay = event.endDate

--- a/sanity/lib/dateFormatters.ts
+++ b/sanity/lib/dateFormatters.ts
@@ -1,0 +1,65 @@
+/**
+ * Date formatting utilities for events
+ * Extracts time directly from ISO strings without timezone conversion
+ */
+
+/**
+ * Formats event time without timezone conversion
+ * Example: "2026-02-07T08:00:00Z" → "8:00 AM"
+ */
+export const formatEventTime = (isoString: string): string => {
+  if (!isoString) return "";
+
+  try {
+    // Extract time from ISO string using regex
+    // Format: YYYY-MM-DDTHH:mm:ss
+    const timeMatch = isoString.match(/T(\d{2}):(\d{2}):/);
+    if (!timeMatch) return "";
+
+    const hour = parseInt(timeMatch[1], 10);
+    const minute = parseInt(timeMatch[2], 10);
+
+    // Convert to 12-hour format
+    const period = hour >= 12 ? "PM" : "AM";
+    const displayHour = hour % 12 === 0 ? 12 : hour % 12;
+
+    return `${displayHour}:${minute.toString().padStart(2, "0")} ${period}`;
+  } catch {
+    return "";
+  }
+};
+
+/**
+ * Formats event date
+ * Example: "2026-02-07T08:00:00Z" → "February 7, 2026"
+ */
+export const formatEventDate = (isoString: string): string => {
+  if (!isoString) return "";
+
+  try {
+    const date = new Date(isoString);
+    return date.toLocaleDateString("en-US", {
+      month: "long",
+      day: "numeric",
+      year: "numeric",
+    });
+  } catch {
+    return "";
+  }
+};
+
+/**
+ * Formats event time range
+ * Example: formatEventTimeRange("2026-02-07T08:00:00Z", "2026-02-08T08:00:00Z")
+ * → "8:00 AM - 8:00 AM"
+ */
+export const formatEventTimeRange = (
+  startIsoString: string,
+  endIsoString?: string
+): string => {
+  const startTime = formatEventTime(startIsoString);
+  if (!endIsoString) return startTime;
+
+  const endTime = formatEventTime(endIsoString);
+  return `${startTime} - ${endTime}`;
+};


### PR DESCRIPTION
- Create date formatter utility (sanity/lib/dateFormatters.ts)
- Implement formatEventTime, formatEventDate, formatEventTimeRange functions
- Extract time directly from ISO strings without timezone conversion
- Update app/events/[slug]/page.tsx to use new formatters
- Update app/components/events/EventsListing.tsx to use new formatters
- Fixes event times displaying incorrectly due to browser timezone conversion